### PR TITLE
Fixed count of healthy people + added portuguese translation

### DIFF
--- a/src/plugins/epidemic/header.js
+++ b/src/plugins/epidemic/header.js
@@ -111,6 +111,7 @@ var statistics = {
     set currentCured(value) {
         this._currentCured = value;
         counters.immune.innerHTML = this._currentCured;
+        counters.healthy.innerHTML = this.currentHealthy;
     },
 
     /* Current deaths */
@@ -120,6 +121,7 @@ var statistics = {
     set currentDead(value) {
         this._currentDead = value;
         counters.dead.innerHTML = this._currentDead;
+        counters.healthy.innerHTML = this.currentHealthy;
     },
 
     /* Current deaths because of lack of intensive care beds */

--- a/src/plugins/translator/translator.js
+++ b/src/plugins/translator/translator.js
@@ -5,223 +5,261 @@
  * English: Luca Dibattista
  * Italian: Luca Dibattista
  * Dutch:   Gregory V. H.
+ * Portuguese: Ana Paula D. Marques
  */
 translator_strings = {
     'languages': {
         'en': 'English',
         'it': 'Italiano',
         'nl': 'Olandese',
-        'de': 'Deutsch'
+        'de': 'Deutsch',
+        'pt': 'Português'
     },
     'title': {
         'en': 'Epidemic simulator',
         'it': 'Simulatore di epidemie',
         'nl': 'Epidemie simulator',
-        'de': 'Epidemie Simulator'
+        'de': 'Epidemie Simulator',
+        'pt': 'Simulador Epidêmico'
     },
     'infected': {
         'en': 'infected',
         'it': 'infetti',
         'nl': 'geïnfecteerd',
-        'de': 'infiziert'
+        'de': 'infiziert',
+        'pt': 'infectados'
     },
     'healthy': {
         'en': 'healthy',
         'it': 'sani',
         'nl': 'gezond',
-        'de': 'gesund'
+        'de': 'gesund',
+        'pt': 'saudáveis'
     },
     'cured': {
         'en': 'cured',
         'it': 'curati',
         'nl': 'genezen',
-        'de': 'genesen'
+        'de': 'genesen',
+        'pt': 'curados'
     },
     'dead': {
         'en': 'deaths',
         'it': 'morti',
         'nl': 'doden',
-        'de': 'verstorben'
+        'de': 'verstorben',
+        'pt': 'mortos'
     },
     'Dead': {
         'en': 'Dead',
         'it': 'Morti',
         'nl': 'Doden',
-        'de': 'Verstorben'
+        'de': 'Verstorben',
+        'pt': 'Mortos'
     },
     'of_which': {
         'en': 'of which',
         'it': 'di cui',
         'nl': 'waarvan',
-        'de': 'davon'  
+        'de': 'davon',
+        'pt': 'dos quais'  
     },
     'for_missing_beds': {
         'en': 'for missing beds in intensive care',
         'it': 'per mancanza di posti in terapia intensiva',
         'nl': 'door niet genoeg plaatsen op intensive care',
-        'de': 'aufgrund von mangeldem Platz auf Intensivstationen'
+        'de': 'aufgrund von mangeldem Platz auf Intensivstationen',
+        'pt': 'por falta de leitos na UTI'
     },
     'people': {
         'en': 'people',
         'it': 'persone',
         'nl': 'mensen',
-        'de': 'Personen'
+        'de': 'Personen',
+        'pt': 'pessoas'
     },
     'quarantine': {
         'en': 'Quarantine',
         'it': 'Quarantena',
         'nl': 'Quarantaine',
-        'de': 'Quarantine'
+        'de': 'Quarantine',
+        'pt': 'Quarentena'
     },
     'intensive_care': {
         'en': 'Intensive care',
         'it': 'Terapia intensiva',
         'nl': 'Intensive care',
-        'de': 'Intensivstationen'
+        'de': 'Intensivstationen',
+        'pt': 'UTI'
     },
     'simulation_parameters': {
         'en': 'Simulation parameters',
         'it': 'Parametri simulazione',
         'nl': 'Simulatie parameters',
-        'de': 'Simulations Parameter'
+        'de': 'Simulations Parameter',
+        'pt': 'Parâmetros da simulação'
     },
     'simulation_initial_population': {
         'en': 'Initial population',
         'it': 'Popolazione iniziale',
         'nl': 'Initiële populatie',
-        'de': 'Initiale Population'
+        'de': 'Initiale Population',
+        'pt': 'População inicial'
     },
     'simulation_initial_population_help': {
         'en': 'Number of total people',
         'it': 'Persone totali',
         'nl': 'Totaal aantal mensen',
-        'de': 'Anzahl an Menschen'
+        'de': 'Anzahl an Menschen',
+        'pt': 'Número total de pessoas'
     },
     'simulation_initial_infected': {
         'en': 'Initial infected',
         'it': 'Infetti iniziali',
         'nl': 'Initieel aantal geïnfecteerd',
-        'de': 'Anfänglich Infizierte'
+        'de': 'Anfänglich Infizierte',
+        'pt': 'Infectados iniciais'
     },
     'simulation_initial_infected_help': {
         'en': 'Number of initial people infected',
         'it': 'Numero di persone inizialmente infette',
         'nl': 'Aantal mensen die geïnfecteerd zijn',
-        'de': 'Anzahl an anfänglich infizierten Menschen'
+        'de': 'Anzahl an anfänglich infizierten Menschen',
+        'pt': 'Número inicial de infectados'
     },
     'simulation_people_speed': {
         'en': 'People speed',
         'it': 'Velocità delle persone',
         'nl': 'Snelheid van mensen',
-        'de': 'Bewegungsgeschwindigkeit'
+        'de': 'Bewegungsgeschwindigkeit',
+        'pt': 'Velocidade das pessoas'
     },
     'simulation_people_speed_help': {
         'en': 'Speed with which people move.\nDecrease it to simulate lockdown',
         'it': 'La velocità con la quale si muovono le persone.\nDiminuire per simulare il lockdown',
         'nl': 'Snelheid waarmee mensen zich voortbewegen.\nVerminderen om lockdown te simuleren',
-        'de': 'Geschwindigkeit mit der sich Personen bewegen. \n Veringern um Lockdown zu simulieren'
+        'de': 'Geschwindigkeit mit der sich Personen bewegen. \n Veringern um Lockdown zu simulieren',
+        'pt': 'Velocidade que as pessoas se movem. \nDiminua para simular o lockdown'
     },
     'simulation_desease_duration': {
         'en': 'Desease duration',
         'it': 'Durata malattia',
         'nl': 'Ziektetijd',
-        'de': 'Krankheitsdauer'
+        'de': 'Krankheitsdauer',
+        'pt': 'Duração da doença'
     },
     'simulation_desease_duration_help': {
         'en': 'How many days before dying or healing',
         'it': 'Quanti giorni passano prima di guarire o morire',
         'nl': 'Hoelang het duurt om te genezen',
-        'de': 'Anzahl der Tage bis zur Heilung oder Tod'
+        'de': 'Anzahl der Tage bis zur Heilung oder Tod',
+        'pt': 'Quantos dias se passaram antes de morrer ou se curar'
     },
     'simulation_infection_rate': {
         'en': 'Infection rate',
         'it': 'Infettività',
         'nl': 'Infectiegraad',
-        'de': 'Infektionsrate'
+        'de': 'Infektionsrate',
+        'pt': 'Taxa de infecção'
+        
     },
     'simulation_infection_rate_help': {
         'en': 'The probability for an infected to infect another person in the nearby',
         'it': 'La probabilità per un infetto di infettare una persona che si trova nelle vicinanze',
         'nl': 'De kans dat een geïnfecteerde persoon iemand anders infecteerd',
-        'de': 'Die Wahrscheinlichkeit dass eine Person eine andere Person in der Nähe infiziert'
+        'de': 'Die Wahrscheinlichkeit dass eine Person eine andere Person in der Nähe infiziert',
+        'pt': 'A probabilidade de uma pessoa infectada infectar outra pessoa próxima'
     },
     'simulation_lethality': {
         'en': 'Lethality',
         'it': 'Letalità',
         'nl': 'Dodelijkheid',
-        'de': 'Tötlichkeit'
+        'de': 'Tötlichkeit',
+        'pt': 'Letalidade'
     },
     'simulation_lethality_help': {
         'en': 'The probability for an infected to die',
         'it': 'La probabilità che un infetto muoia',
         'nl': 'De kans dat iemand sterft aan het virus',
-        'de': 'Die Wahrscheinlichkeit eines Infizierten zu sterben'
+        'de': 'Die Wahrscheinlichkeit eines Infizierten zu sterben',
+        'pt': 'A probabilidade de uma pessoa infectada morrer'
     },
     'simulation_activate_quarantine': {
         'en': 'Activate quarantine',
         'it': 'Attiva quarantena',
         'nl': 'Activeer quarantaine',
-        'de': 'Quarantäne aktiv'
+        'de': 'Quarantäne aktiv',
+        'pt': 'Ativar quarentena'
     },
     'simulation_days_before_quarantine': {
         'en': 'Days before quarantine',
         'it': 'Giorni prima della quarantena',
         'nl': 'Dagen vóór quarantaine',
-        'de': 'Tage bis zur Quarantänisierung'
+        'de': 'Tage bis zur Quarantänisierung',
+        'pt': 'Dias antes da quarentena'
     },
     'simulation_days_before_quarantine_help': {
         'en': 'How many days before showing symphtoms and going in quarantine',
         'it': 'Quanti giorni passano prima che si mostrino i sintomi e si vada in quarantena',
         'nl': 'Hoeveel dagen voordat symptomen zichtbaar zijn en men in quarantaine gaat',
-        'de': 'Wie viele Tage vergehen bis Symptome auftreten und eine Peron in Quarantäne geht'
+        'de': 'Wie viele Tage vergehen bis Symptome auftreten und eine Peron in Quarantäne geht',
+        'pt': 'Quantos dias até aparecerem os sintomas e o indivíduo ficar de quarentena'
     },
     'simulation_asymptomatic_rate': {
         'en': 'Asymptomatic rate',
         'it': 'Asintomaticità',
         'nl': 'Asymptomatiegraad',
-        'de': 'Anteil asymptomatischer Fälle'
+        'de': 'Anteil asymptomatischer Fälle',
+        'pt': 'Taxa de assintomáticos'
     },
     'simulation_asymptomatic_rate_help': {
         'en': 'How many, among people who get the virus, don\'t go in quarantine (maybe for not showing symphtoms)',
         'it': 'Quanti, tra le persone che prendono in virus, non vanno in quarantena (magari per non aver mostrato i sintomi)',
         'nl': 'Hoeveel mensen, onder de mensen die het virus hebben, niet in quarantaine gaan (mogelijks omdat geen symptomen zichtbaar zijn)',
-        'de': 'Anteil der Infizierten, welche nicht in Quaratäne gehen (z.B. weil sie keine Symptome zeigen)'
+        'de': 'Anteil der Infizierten, welche nicht in Quaratäne gehen (z.B. weil sie keine Symptome zeigen)',
+        'pt': 'Porcentagem de pessoas, entre as que pegaram o vírus e não ficarão em quarentena (talvez por não apresentar os sintomas)'
     },
     'simulation_icu_rate': {
         'en': 'Intensive care rate',
         'it': 'Terapia intensiva',
         'nl': 'Intensive care',
-        'de': 'Anteil Intensivbetreuung'
+        'de': 'Anteil Intensivbetreuung',
+        'pt': 'UTI'
     },
     'simulation_icu_rate_help': {
         'en': 'How many, among people who get the virus, need intensive care to not die',
         'it': 'Quanti, tra le persone che prendono il virus, hanno bisogno della terapia intensiva per non morire',
         'nl': 'Hoeveel mensen, onder de mensen die het virus hebben, moeten op intensive care verzorgd worden om te overleven',
-        'de': 'Anteil der Infizierten welche eine Intensivpflege brauchen um zu überleben'
+        'de': 'Anteil der Infizierten welche eine Intensivpflege brauchen um zu überleben',
+        'pt': 'Porcentagem de pessoas infectadas que necessitam de UTI para não morrerem'
     },
     'simulation_icu_every_100': {
         'en': 'Number of IC units every 100 people',
         'it': 'Posti in terapia intensiva ogni 100 persone',
         'nl': 'Aantal IC bedden per 100 personen',
-        'de': 'Anzahl der Intensivbetten pro 100 Personen'
+        'de': 'Anzahl der Intensivbetten pro 100 Personen',
+        'pt': 'Número de leitos de UTI por 100 pessoas'
     },
     'simulation_icu_every_100_help': {
         'en': 'E.g.: if there are 2 beds for 200 people, put "1" (1 bed every 100 people).\nIf there are no beds available, people who need IC will die',
         'it': 'Esempio: se ci sono 2 posti per 200 persone, inserire "1" (1 letto ogni 100 persone).\nQuando i posti in terapia intensiva terminano, le persone che ne hanno bisogno moriranno',
         'nl': 'Bijvoorbeeld: als er 2 bedden zijn voor 200 personen, zet dit op "1" (1 bed per 100 personen)\nAls er geen bedden beschikbaar zijn zullen mensen die deze zorgen nodig hebben sterven',
         'de': 'Zum Beispiel: Wenn es 2 Betten für 200 Personen gibt, setzen Sie "1" (1 Bett alle 100 Personen).\nWenn keine Betten verfügbar sind, sterben Menschen, die IC benötigen',
+        'pt': 'Exemplo: Se são 2 leitos para 200 pessoas, inserir "1" (1 leito para 100 pessoas). \nSe não há nenhum leito disponível, pessoas que necessitarem dos leitos de UTI irão falecer'
     },
     'stop_simulation': {
         'en': 'Stop simulation',
         'it': 'Ferma simulazione',
         'nl': 'Stop simulatie',
-        'de': 'Stop Simulation'
+        'de': 'Stop Simulation',
+        'pt': 'Parar simulação'
     },
     'start_simulation': {
         'en': 'Start simulation',
         'it': 'Avvia simulazione',
         'nl': 'Start simulatie',
-        'de': 'Start Simulation'
+        'de': 'Start Simulation',
+        'pt': 'Iniciar simulação'
     },
 };
 
@@ -244,6 +282,9 @@ $(document).ready(function(){
     let browser_language = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage)
     let language;
     switch(browser_language){
+        case 'pt':
+            language = 'pt';
+            break;
         case 'de':
             language = 'de';
             break;


### PR DESCRIPTION
**Problem**
There is a problem with the number of healthy people at the end of the simulation. Always remains one healthy person. If we sum the number of deaths, cured and healthy it will be greater than the initial population. 

**Solution**
To fix this, it just needs to update the number of healthy people on src/plugins/epidemic/header.js when the current Dead and Cured are set, i.e. in the _set currentDead()_ and _set currentDead()_.

**Added Brazilian Portuguese translation**
Some words between Portugal Portuguese and Brazilian Portuguese may differ but in general, it can be understood.